### PR TITLE
Add history check

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ This means:
    layer up: `100 -> 110 -> 111`.  (*Note*: the number of layers in each string
    must match the number of layers in the svg file).
 
+### Warning
+
+The contents of the *slidemachine* output directory (`slidemachine_media` by
+default) should not be changed manually.  *slidemachine* deletes any files that
+it does not need for the current processing.  This means that any user-added
+files in this directory will be deleted.  
+
 ### Intriguing thoughts
 
  + The code is modular enough that we should be able to drop basically any

--- a/slidemachine/config.json
+++ b/slidemachine/config.json
@@ -5,9 +5,11 @@
             "target_dir":"slidemachine_media",
             "img_format":"png",
             "text_to_path":true,
-            "pattern":"!\\[sm.inkscape\\]"},
+            "pattern":"!\\[sm.inkscape\\]",
+            "prev_build_json":"prev-build.json"},
         "ImageProcessor":{
             "target_dir":"slidemachine_media",
-            "pattern":"!\\[sm.image\\]"}
+            "pattern":"!\\[sm.image\\]",
+            "prev_build_json":"prev-build.json"}
      }
 }

--- a/slidemachine/console/slidemachine.py
+++ b/slidemachine/console/slidemachine.py
@@ -28,7 +28,10 @@ def main(argv=None):
     parser.add_argument("--target-dir",type=str,default=None,
                         help="directory to hold slidemachine media (overrides json)")
     parser.add_argument("--force",action="store_true",
-                        help="delete old media directories and output files")
+                        help="overwrite existing html")
+    parser.add_argument("--wipe",action="store_true",
+                        help="delete output directory and render all files from scratch")
+
 
     args = parser.parse_args(argv)
     markdown_file = args.markdown_file[0]
@@ -36,7 +39,8 @@ def main(argv=None):
     s = slidemachine.SlideMachine(markdown_file,
                                   target_dir=args.target_dir,
                                   json_file=args.config,
-                                  force=args.force)
+                                  force=args.force,
+                                  wipe=args.wipe)
 
     s.process(output_file=args.out,
               reveal_html_file=args.template)

--- a/slidemachine/processors/base.py
+++ b/slidemachine/processors/base.py
@@ -5,7 +5,7 @@ Define base processor class.
 __author__ = "Michael J. Harms"
 __date__ = "2018-05-10"
 
-import os, hashlib, shutil, re
+import os, hashlib, shutil, re, json, copy
 
 def _split_string(s, delim, escape='\\'):
     """
@@ -62,7 +62,8 @@ class Processor:
         # List of output files associated with this processor
         self._output_files = []
 
-        self._name = self.__class__.__name
+        self._name = self.__class__.__name__
+        self._prev_build_dict = {}
 
     def _get_file_md5(self,input_file):
         """
@@ -157,7 +158,7 @@ class Processor:
 
         # Get current json content
         try:
-            current_json_contents = json.load(json_file)
+            current_json_contents = json.load(open(json_file,'r'))
         except FileNotFoundError:
             current_json_contents = {}
 
@@ -166,7 +167,7 @@ class Processor:
 
         # Write out
         f = open(json_file,'w')
-        json.dump(current_json_content,f)
+        json.dump(current_json_contents,f)
         f.close()
 
 

--- a/slidemachine/processors/base.py
+++ b/slidemachine/processors/base.py
@@ -39,7 +39,8 @@ class Processor:
     Base class for all processor subclasses in slidemachine.
     """
 
-    def __init__(self,target_dir,pattern="!\[sm.dummy\]"):
+    def __init__(self,target_dir,pattern="!\[sm.dummy\]",
+                 prev_build_json="prev-build.json"):
         """
         target_dir: place to store output files
         pattern: markdown pattern that should invoke this processor
@@ -47,6 +48,7 @@ class Processor:
 
         self._target_dir = target_dir
         self._pattern = re.compile(pattern)
+        self._prev_build_json = prev_build_json
 
         # Dictionary of every file seen during processing. key is the
         # md5 hash of the file; value is the filename.  This is used to
@@ -150,11 +152,11 @@ class Processor:
 
     def write_build_json(self):
         """
-        Write build information from this run to prev-build.json.
+        Write build information from this run to previous build json.
         """
 
         # Json output file
-        json_file = os.path.join(self._target_dir,"prev-build.json")
+        json_file = os.path.join(self._target_dir,self._prev_build_json)
 
         # Get current json content
         try:
@@ -193,3 +195,7 @@ class Processor:
     @property
     def output_files(self):
         return self._output_files
+
+    @property
+    def prev_build_json(self):
+        return os.path.join(self._target_dir,self._prev_build_json)

--- a/slidemachine/processors/inkscape.py
+++ b/slidemachine/processors/inkscape.py
@@ -395,12 +395,14 @@ class InkscapeProcessor(Processor):
                  target_dir="slidemachine.data",
                  img_format="png",
                  text_to_path=True,
-                 pattern="!\[sm.inkscape\]"):
+                 pattern="!\[sm.inkscape\]",
+                 prev_build_json="prev-build.json"):
         """
         target_dir: directory in which to write out rendered files
         img_format: image format (png, pdf, svg)
         text_to_path: convert text in svg to path
         pattern: pattern to use to look for inkscape lines in markdown
+        prev_build_json: file where previous build information is stored
         """
 
         self._img_format = img_format
@@ -408,7 +410,8 @@ class InkscapeProcessor(Processor):
 
         self._configs_rendered = {}
 
-        super(InkscapeProcessor, self).__init__(target_dir,pattern)
+        super(InkscapeProcessor, self).__init__(target_dir,pattern,
+                                                prev_build_json)
 
     def process(self,line):
         """

--- a/slidemachine/slidemachine.py
+++ b/slidemachine/slidemachine.py
@@ -246,8 +246,7 @@ class SlideMachine:
 
             # Read a json file that indicates what has been done previously
             try:
-                prev_build = os.path.join(p.target_dir,"prev-build.json")
-                prev_json = json.load(open(prev_build,'r'))
+                prev_json = json.load(open(p.prev_build_json,'r'))
                 prev_proc = prev_json[processor_name]
 
                 p.add_previous_build_information(prev_proc)
@@ -262,7 +261,7 @@ class SlideMachine:
             # Make sure this does not have prev-build.json.  (If it did, we
             # would delete it later as a leftover file)
             try:
-                existing_files.remove(os.path.join(p.target_dir,"prev-build.json"))
+                existing_files.remove(p.prev_build_json)
             except ValueError:
                 pass
 
@@ -274,8 +273,7 @@ class SlideMachine:
         # Remove any previous build information
         for p in self._processors:
             try:
-                prev_build = os.path.join(p.target_dir,"prev-build.json")
-                os.remove(prev_build)
+                os.remove(p.prev_build_json)
             except FileNotFoundError:
                 pass
 

--- a/slidemachine/slidemachine.py
+++ b/slidemachine/slidemachine.py
@@ -247,7 +247,7 @@ class SlideMachine:
             # Read a json file that indicates what has been done previously
             try:
                 prev_build = os.path.join(p.target_dir,"prev-build.json")
-                prev_json = json.load(open(prev_build),'r')
+                prev_json = json.load(open(prev_build,'r'))
                 prev_proc = prev_json[processor_name]
 
                 p.add_previous_build_information(prev_proc)
@@ -259,17 +259,17 @@ class SlideMachine:
             existing_files = [os.path.join(p.target_dir,f)
                               for f in os.listdir(p.target_dir)]
 
+            # Make sure this does not have prev-build.json.  (If it did, we
+            # would delete it later as a leftover file)
+            try:
+                existing_files.remove(os.path.join(p.target_dir,"prev-build.json"))
+            except ValueError:
+                pass
+
             self._existing_files.extend(existing_files)
 
         # Set of all files already present in output directory(s)
         self._existing_files = set(self._existing_files)
-
-        # Make sure this does not have prev-build.json.  (If it did, we would
-        # delete it later as a leftover file)
-        try:
-            self._existing_files.remove("prev-build.json")
-        except ValueError:
-            pass
 
         # Remove any previous build information
         for p in self._processors:
@@ -418,7 +418,6 @@ class SlideMachine:
         leftover_files = self._existing_files.difference(all_output_files)
         for f in leftover_files:
             os.remove(f)
-
 
         # Grab slide html
         html = []


### PR DESCRIPTION
Now writes out .json file that records processing done.  If the user runs slidemachine again with the same output directory, slidemachine now reads that file and only renders things that have changed.  (Currently only works for the InkscapeProcessor class).  